### PR TITLE
Add the hydrostatic option

### DIFF
--- a/RUN/SFS_options.yaml
+++ b/RUN/SFS_options.yaml
@@ -11,4 +11,8 @@ base:
   ACCOUNT: {{ 'HPC_ACCOUNT' | getenv }} 
   HPSS_PROJECT: "emc-marine"
   BASE_CPLIC: {{ 'TOPICDIR' | getenv }}/REPLAY_ICs/C96mx100
+fcst:
+  TYPE: "hydro"
+  MONO: "mono"
+
 

--- a/parm/config/gefs/config.fcst
+++ b/parm/config/gefs/config.fcst
@@ -60,8 +60,8 @@ export FCSTEXEC="ufs_model.x"
 
 #######################################################################
 # Model configuration
-export TYPE="nh"
-export MONO="non-mono"
+export TYPE="@TYPE@"
+export MONO="@MONO@"
 
 # Use stratosphere h2o physics
 export h2o_phys=".true."
@@ -193,7 +193,12 @@ case ${imp_physics} in
         export hord_xx_nh_nonmono=5
         export vtdm4_nh_nonmono=0.02
         export nord=2
-        export dddmp=0.1
+        if [[ "${TYPE}" == "nh"* ]]; then
+            export dddmp=0.1
+        else
+            export dddmp=0.
+	fi
+
         export d4_bg=0.12
         ;;
     11) # GFDL
@@ -213,7 +218,11 @@ case ${imp_physics} in
         export vtdm4_nh_nonmono=0.02
         export nord=2
         export d4_bg=0.12
-        export dddmp=0.1
+        if [[ "${TYPE}" == "nh"* ]]; then
+            export dddmp=0.1
+        else
+            export dddmp=0.
+	fi
         ;;
     *) echo "Unknown microphysics option, ABORT!" ;;
 esac

--- a/parm/config/gefs/yaml/defaults.yaml
+++ b/parm/config/gefs/yaml/defaults.yaml
@@ -11,3 +11,6 @@ base:
   FHMAX_GFS: 120
   FHMAX_HF_GFS: 0
   REPLAY_ICS: "NO"
+fcst:
+  TYPE: "nh"
+  MONO: "non-mono"

--- a/parm/config/gfs/config.fcst
+++ b/parm/config/gfs/config.fcst
@@ -72,8 +72,8 @@ export FCSTEXEC="ufs_model.x"
 
 #######################################################################
 # Model configuration
-export TYPE="nh"
-export MONO="non-mono"
+export TYPE="@TYPE@"
+export MONO="@MONO@"
 
 # Use stratosphere h2o physics
 export h2o_phys=".true."
@@ -209,7 +209,11 @@ case ${imp_physics} in
         export hord_xx_nh_nonmono=5
         export vtdm4_nh_nonmono=0.02
         export nord=2
-        export dddmp=0.1
+        if [[ "${TYPE}" == "nh"* ]]; then
+          export dddmp=0.1
+	else
+          export dddmp=0.
+	fi
         export d4_bg=0.12
 
         if [[ "${CCPP_SUITE}" == "FV3_global_nest"* ]]; then
@@ -243,7 +247,11 @@ case ${imp_physics} in
         export vtdm4_nh_nonmono=0.02
         export nord=2
         export d4_bg=0.12
-        export dddmp=0.1
+        if [[ "${TYPE}" == "nh"* ]]; then
+          export dddmp=0.1
+	else
+          export dddmp=0.
+	fi
         ;;
     *) echo "Unknown microphysics option, ABORT!" ;;
 esac

--- a/parm/config/gfs/yaml/defaults.yaml
+++ b/parm/config/gfs/yaml/defaults.yaml
@@ -20,6 +20,9 @@ base:
   GSI_SOILANAL: "NO"
   EUPD_CYC: "gdas"
   FHMAX_ENKF_GFS: 12
+fcst:
+  TYPE: "nh"
+  MONO: "non-mono"
 
 atmanl:
   JCB_ALGO_YAML: "${PARMgfs}/gdas/atm/jcb-prototype_3dvar.yaml.j2" 

--- a/parm/ufs/fv3/diag_table
+++ b/parm/ufs/fv3/diag_table
@@ -77,6 +77,7 @@
 #"gfs_dyn",     "pfhy",        "preshy",       "fv3_history",    "all",  .false.,  "none",  2
 #"gfs_dyn",     "pfnh",        "presnh",       "fv3_history",    "all",  .false.,  "none",  2
 "gfs_dyn",     "w",           "dzdt",         "fv3_history",    "all",  .false.,  "none",  2
+"gfs_dyn",     "omga",        "omga",         "fv3_history",    "all",  .false.,  "none",  2
 "gfs_dyn",     "ps",          "pressfc",      "fv3_history",    "all",  .false.,  "none",  2
 "gfs_dyn",     "hs",          "hgtsfc",       "fv3_history",    "all",  .false.,  "none",  2
 "gfs_phys",    "refl_10cm",   "refl_10cm",    "fv3_history",    "all",  .false.,  "none",  2

--- a/sorc/build_ufs.sh
+++ b/sorc/build_ufs.sh
@@ -7,6 +7,7 @@ cwd=$(pwd)
 APP="S2SWA"
 CCPP_SUITES="FV3_GFS_v17_p8_ugwpv1,FV3_GFS_v17_coupled_p8_ugwpv1,FV3_global_nest_v1"  # TODO: does the g-w need to build with all these CCPP_SUITES?
 PDLIB="ON"
+HYDRO="ON"
 
 while getopts ":da:fj:vw" option; do
   case "${option}" in
@@ -32,6 +33,7 @@ source "./tests/module-setup.sh"
 
 MAKE_OPT="-DAPP=${APP} -D32BIT=ON -DCCPP_SUITES=${CCPP_SUITES}"
 [[ ${PDLIB:-"OFF"} = "ON" ]] && MAKE_OPT+=" -DPDLIB=ON"
+[[ ${HYDRO:-"OFF"} = "ON" ]] && MAKE_OPT+=" -DHYDRO=ON"
 if [[ ${BUILD_TYPE:-"Release"} = "DEBUG" ]] ; then
     MAKE_OPT+=" -DDEBUG=ON"
 elif [[ "${FASTER:-OFF}" == ON ]] ; then

--- a/ush/forecast_predet.sh
+++ b/ush/forecast_predet.sh
@@ -279,6 +279,7 @@ FV3_predet(){
     phys_hydrostatic=".false."     # ignored when hydrostatic = T
     use_hydro_pressure=".false."   # ignored when hydrostatic = T
     make_nh=".false."              # running in hydrostatic mode
+    fast_tau_w_sec=0
   fi
 
   # Conserve total energy as heat globally
@@ -301,9 +302,16 @@ FV3_predet(){
     if [[ "${TYPE}" == "nh" ]]; then  # monotonic and non-hydrostatic
       hord_mt=${hord_mt_nh_mono:-"10"}
       hord_xx=${hord_xx_nh_mono:-"10"}
+      hord_dp=${hord_xx_nh_mono:-"10"}
     else  # monotonic and hydrostatic
       hord_mt=${hord_mt_hydro_mono:-"10"}
       hord_xx=${hord_xx_hydro_mono:-"10"}
+      hord_dp=${hord_xx_hydro_mono:-"10"}
+      kord_tm=${kord_tm_hydro_mono:-"-12"}
+      kord_mt=${kord_mt_hydro_mono:-"12"}
+      kord_wz=${kord_wz_hydro_mono:-"12"}
+      kord_tr=${kord_tr_hydro_mono:-"12"}
+
     fi
   else  # non-monotonic options
     d_con=${d_con_nonmono:-"1."}
@@ -311,9 +319,11 @@ FV3_predet(){
     if [[ "${TYPE}" == "nh" ]]; then  # non-monotonic and non-hydrostatic
       hord_mt=${hord_mt_nh_nonmono:-"5"}
       hord_xx=${hord_xx_nh_nonmono:-"5"}
+      hord_dp=-${hord_xx_nh_nonmono:-"5"}
     else # non-monotonic and hydrostatic
       hord_mt=${hord_mt_hydro_nonmono:-"10"}
       hord_xx=${hord_xx_hydro_nonmono:-"10"}
+      hord_dp=${hord_xx_hydro_nonmono:-"10"}
     fi
   fi
 

--- a/ush/parsing_namelists_FV3.sh
+++ b/ush/parsing_namelists_FV3.sh
@@ -150,7 +150,7 @@ cat > input.nml <<EOF
   hord_mt = ${hord_mt}
   hord_vt = ${hord_xx}
   hord_tm = ${hord_xx}
-  hord_dp = -${hord_xx}
+  hord_dp = ${hord_dp}
   hord_tr = ${hord_tr:-"8"}
   adjust_dry_mass = ${adjust_dry_mass:-".true."}
   dry_mass=${dry_mass:-98320.0}


### PR DESCRIPTION
# Description

Add the option to run hydrostatic. 

How to run hydrostatic:
1) HYDRO="ON" in ~/sorc/build_ufs.sh.  It should be set to "OFF" if you want to run "nh".
2) TYPE="hydro" and MONO="mono". It can be defined in *yaml file when setting up workflow. 
The default remains "nh" and "non-mono".
 
# Type of change
<!-- Delete all except one -->

- New feature (adds functionality)


# Change characteristics
- Is this a breaking change (a change in existing functionality)? NO
- Does this change require a documentation update? NO

# How has this been tested?

- Forecast-only on Hera


# Checklist
- [x] Any dependent changes have been merged and published
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing tests pass with my changes
- [x] I have made corresponding changes to the documentation if necessary
